### PR TITLE
Fix Issue #22

### DIFF
--- a/R/access.R
+++ b/R/access.R
@@ -17,7 +17,7 @@
 #' @import datapack
 #' @export
 set_rights_holder <- function(mn, pids, subject) {
-  stopifnot(class(mn) == "MNode")
+  stopifnot(is(mn, "MNode"))
   stopifnot(is.character(pids),
             all(nchar(pids) > 0))
   stopifnot(is.character(subject),
@@ -141,7 +141,7 @@ set_public_read <- function(mn, pids) {
 #'
 #' @examples
 remove_public_read <- function(mn, pids) {
-  stopifnot(class(mn) == "MNode",
+  stopifnot(is(mn, "MNode"),
             all(is.character(pids)),
             all(nchar(pids) > 0))
 
@@ -215,7 +215,7 @@ remove_public_read <- function(mn, pids) {
 #'
 #' @examples
 set_rights_and_access <- function(mn, pids, subject, permissions=c("read", "write", "changePermission")) {
-  stopifnot(class(mn) == "MNode",
+  stopifnot(is(mn, "MNode"),
             all(is.character(pids)),
             all(nchar(pids) > 0),
             is.character(subject),

--- a/R/dataone.R
+++ b/R/dataone.R
@@ -97,7 +97,7 @@ is_token_expired <- function(node) {
 #' @examples
 get_mn_base_url <- function(mn) {
   # Determine MN URL. Accept either an MNode or a character string
-  if (class(mn) == "MNode") {
+  if (is(mn, "MNode")) {
     mn_base_url <- mn$base_url
   }
 

--- a/R/editing.R
+++ b/R/editing.R
@@ -30,7 +30,7 @@ publish_object <- function(mn,
                            clone_pid=NULL,
                            public=TRUE) {
 
-  stopifnot(class(mn) == "MNode")
+  stopifnot(is(mn, "MNode"))
   stopifnot(file.exists(path))
 
   # Decide the format_id
@@ -509,7 +509,7 @@ create_resource_map <- function(mn,
                                 data_pids=NULL,
                                 child_pids=NULL,
                                 check_first=TRUE) {
-  stopifnot(class(mn) == "MNode")
+  stopifnot(is(mn, "MNode"))
   stopifnot(is.character(metadata_pid),
             nchar(metadata_pid) > 0)
 
@@ -591,7 +591,7 @@ update_resource_map <- function(mn,
                                 check_first=TRUE) {
 
   # Check arguments
-  stopifnot(class(mn) == "MNode")
+  stopifnot(is(mn, "MNode"))
   stopifnot(is.character(resource_map_pid),
             nchar(resource_map_pid) > 0)
   stopifnot(is.character(metadata_pid),
@@ -613,7 +613,7 @@ update_resource_map <- function(mn,
 
   # Get the current rightsHolder
   sysmeta <- dataone::getSystemMetadata(mn, resource_map_pid)
-  stopifnot(class(sysmeta) == "SystemMetadata")
+  stopifnot(is(sysmeta, "SystemMetadata"))
 
   previous_rights_holder <- sysmeta@rightsHolder
 
@@ -648,7 +648,7 @@ update_resource_map <- function(mn,
 
   message(paste0("Getting updated copy of System Metadata for ", resource_map_pid))
   sysmeta <- dataone::getSystemMetadata(mn, resource_map_pid)
-  stopifnot(class(sysmeta) == "SystemMetadata")
+  stopifnot(is(sysmeta, "SystemMetadata"))
 
   new_rm_sysmeta <- sysmeta
   new_rm_sysmeta@identifier <- identifier

--- a/R/eml.R
+++ b/R/eml.R
@@ -21,7 +21,7 @@
 #' pid_to_other_entity(mn, pkg$data)
 #' }
 pid_to_eml_other_entity <- function(mn, pids) {
-  stopifnot(class(mn) == "MNode")
+  stopifnot(is(mn, "MNode"))
   stopifnot(is.character(pids),
             all(nchar(pids)) > 0)
 
@@ -60,7 +60,7 @@ sysmeta_to_other_entity <- function(mn, pids) {
 #' pid_to_eml_physical(mn, pkg$data)
 #' }
 pid_to_eml_physical <- function(mn, pids) {
-  stopifnot(class(mn) == "MNode")
+  stopifnot(is(mn, "MNode"))
   stopifnot(is.character(pids),
             all(nchar(pids)) > 0)
 
@@ -196,7 +196,7 @@ sysmeta_to_eml_physical <- function(sysmeta) {
 #' set_other_entities(mn, eml_path, "a_data_pid")
 #' }
 set_other_entities <- function(mn, path, pids) {
-  stopifnot(class(mn) == "MNode")
+  stopifnot(is(mn, "MNode"))
   stopifnot(file.exists(path))
   stopifnot(all(is.character(pids)),
             all(nchar(pids) > 0))
@@ -208,7 +208,7 @@ set_other_entities <- function(mn, path, pids) {
 
   # Get the metadata document from the MN and load it as an EML document
   doc <- EML::read_eml(path)
-  stopifnot(class(doc) == "eml")
+  stopifnot(is(doc, "eml"))
 
   message("Setting EML otherEntity elements. This can take a while if there are lots of PIDs...")
 
@@ -237,7 +237,7 @@ set_other_entities <- function(mn, path, pids) {
 #'
 #' @examples
 get_doc_id <- function(sysmeta) {
-  stopifnot(class(sysmeta) == "SystemMetadata")
+  stopifnot(is(sysmeta, "SystemMetadata"))
 
   message("Looking up docid for ", sysmeta@identifier, ".")
 

--- a/R/inventory.R
+++ b/R/inventory.R
@@ -274,7 +274,7 @@ inv_load_identifiers <- function(inventory, paths) {
 #'
 #' @export
 inv_add_extra_columns <- function(inventory) {
-  stopifnot(class(inventory) == "data.frame", "file" %in% names(inventory))
+  stopifnot(is(inventory, "data.frame"), "file" %in% names(inventory))
 
   # Mark metadata files
   cat("Adding 'is_metadata' column.\n")

--- a/R/packaging.R
+++ b/R/packaging.R
@@ -645,12 +645,12 @@ create_object <- function(file, sysmeta, base_path, mn) {
             "pid" %in% names(file),
             "file" %in% names(file))
 
-  stopifnot(class(sysmeta) == "SystemMetadata")
+  stopifnot(is(sysmeta, "SystemMetadata"))
 
   stopifnot(is.character(base_path),
             nchar(base_path) > 0)
 
-  stopifnot(class(env$mn) == "MNode")
+  stopifnot(is(env$mn, "MNode"))
 
   # Set the return value to FALSE by default
   result <- FALSE
@@ -741,7 +741,7 @@ validate_environment <- function(env) {
                               "mn_base_url",
                               "submitter",
                               "rights_holder")
-  stopifnot(class(env) == "list",
+  stopifnot(is(env, "list"),
             length(env) > 0)
   stopifnot(!is.null(env), length(env) > 0)
   stopifnot(all(env_default_components %in% names(env)))

--- a/R/sysmeta.R
+++ b/R/sysmeta.R
@@ -126,7 +126,7 @@ replace_subject <- function(sysmeta,
 #'
 #' @examples
 clear_replication_policy <- function(sysmeta) {
-  if (!(class(sysmeta) == "SystemMetadata")) {
+  if (!(is(sysmeta, "SystemMetadata"))) {
     stop("First argument was not of class SystemMetadata.")
   }
 

--- a/R/util.R
+++ b/R/util.R
@@ -264,7 +264,7 @@ object_exists <- function(node, pids) {
       e
     })
 
-    if (inherits(sysmeta, "error") || class(sysmeta) != "SystemMetadata") {
+    if (inherits(sysmeta, "error") || !is(sysmeta, "SystemMetadata")) {
       result[i] <- FALSE
     } else {
       result[i] <- TRUE
@@ -425,7 +425,7 @@ replace_package_id <- function(path, replacement) {
             nchar(replacement) > 0)
 
   doc <- EML::read_eml(path)
-  stopifnot(class(doc) == "eml")
+  stopifnot(is(doc, "eml"))
 
   doc@packageId <- new("xml_attribute", replacement)
   doc@system <- new("xml_attribute", "arcticdata")
@@ -582,7 +582,7 @@ is_resource_map <- function(node, pids) {
 #'
 #' @examples
 is_obsolete <- function(node, pids) {
-  stopifnot(class(node) == "MNode" || class(node) == "CNode")
+  stopifnot(is(node, "MNode") || is(node, "CNode"))
   stopifnot(is.character(pids))
 
   response <- vector(mode = "logical", length = length(pids))


### PR DESCRIPTION
This commit replaces the class(x)==y statements to use R's is() method.

I had 10 unit test failures so I checked them against the master NCEAS branch. The errors between the untouched NCEAS project and mine were the same. If these were a result of my configuration and not always failing, let me know and I'll fix it up! 

1.  Error: an EML otherEntity subtree can be created when the sysmeta has a filename (@test_eml.R#7)
2.  Error: an EML otherEntity subtree can be created when the sysmeta doesn't have a filename  (@test_eml.R#21)
3.  Error: can load a simple environment file (@test_environment.R#8)
4.  Error: an inventory can be populated with files (@test_inventory.R#14)
5.  Error: an inventory can be populated with byte sizes (@test_inventory.R#43)
6.  Error: an inventory can be populated with checksums (@test_inventory.R#53)
7.  Error: calling things repeatedly does not break things (@test_inventory.R#75)
8.  Error: identifiers can be extracted (@test_util.R#7)
9.  Error: a string can be added to a file (@test_util.R#39)
10. Error: a package id can be changed (@test_util.R#61)