### PR TITLE
Update eml@packageId element in update_object

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,7 @@ Authors@R: c(
   person("Bryce", "Mecum", email = "mecum@nceas.ucsb.edu", role = c("aut", "cre")),
   person("Matt", "Jones", email = "jones@nceas.ucsb.edu", role = "ctb"),
   person("Jeanette", "Clark", email = "jclark@nceas.ucsb.edu", role = "ctb")
+  person("Dominic", "Mullen", email = "dmullen17@gmail.com", role = "ctb")
   )
 Description: This package provides a set of utility methods for uploading
   and  editing data on the Arctic Data Catalog.

--- a/R/editing.R
+++ b/R/editing.R
@@ -176,6 +176,8 @@ update_object <- function(mn, pid, path, format_id=NULL, new_pid=NULL, sid=NULL)
     eml@packageId <- new("xml_attribute", new_pid)
     path <- tempfile()
     EML::write_eml(eml, path)
+    # File changed - update checksum
+    sysmeta@checksum <- digest::digest(path, algo = "sha1", serialize = FALSE, file = TRUE)
   }
 
   # Make the update

--- a/R/editing.R
+++ b/R/editing.R
@@ -170,6 +170,14 @@ update_object <- function(mn, pid, path, format_id=NULL, new_pid=NULL, sid=NULL)
   # Set the replication policy back to default
   sysmeta <- clear_replication_policy(sysmeta)
 
+  # Add packageId to metadata if the object is an xml file
+  if (grepl("^eml:\\/\\/ecoinformatics.org\\/eml", format_id)) {
+    eml <- EML::read_eml(path)
+    eml@packageId <- new("xml_attribute", new_pid)
+    path <- tempfile()
+    EML::write_eml(eml, path)
+  }
+
   # Make the update
   dataone::updateObject(mn,
                         pid = pid,


### PR DESCRIPTION
Resolve #53   Modified `update_object` to set the `eml@packageId` element to the newly generated pid if the `format_id` is a variant of eml://ecoinformatics.org/eml-...  