### PR TITLE
Remove EML access sub-trees

### DIFF
--- a/R/editing.R
+++ b/R/editing.R
@@ -379,7 +379,7 @@ publish_update <- function(mn,
   }
 
   # Replace access if needed
-  if (length(eml@access@allow)) {
+  if (length(eml@access@allow) & (!is.null(metadata_path))) {
     eml@access <- new("access")
   }
 

--- a/R/editing.R
+++ b/R/editing.R
@@ -378,6 +378,11 @@ publish_update <- function(mn,
     eml@system <- new("xml_attribute", "https://arcticdata.io")
   }
 
+  # Replace access if needed
+  if (length(eml@access@allow)) {
+    eml@access <- new("access")
+  }
+
   # Write out the document to disk. We do this in part because
   # set_other_entities takes a path to the doc.
   eml_path <- tempfile()


### PR DESCRIPTION
Resolve #4 

I'm not 100% satisfied with line 230 in testediting.R 
`eml@access@allow <- c(new("allow", .Data = "hello"))`

I messed around with adding a valid access section through R for a while - I can share my attempts to show you what doesn't work if you're interested.  Ultimately settled on creating this dummy allow element that would make `test_equal` fail if `publish_update` did not remove the `eml@access` section properly.