### PR TITLE
remove resource_map_pid from parent_child_pids

### DIFF
--- a/R/editing.R
+++ b/R/editing.R
@@ -287,6 +287,14 @@ publish_update <- function(mn,
     stopifnot(all(is.character(parent_child_pids)))
   }
 
+  # Check to see if the obsoleted package is in the list of parent_child_pids
+  # If it is notify the user and remove it from the list
+  if (resource_map_pid %in% parent_child_pids) {
+    message("Removing the old resource map from the list of child PIDs in the parent package.")
+    resource_map_pid_index <- which(resource_map_pid == parent_child_pids)
+    parent_child_pids <- parent_child_pids[-resource_map_pid_index]
+  }
+
   all_pids <- c(metadata_pid, resource_map_pid, data_pids, child_pids,
                 identifier, parent_resmap_pid, parent_metadata_pid,
                 parent_data_pids, parent_child_pids)


### PR DESCRIPTION
Suggest fix for #36 
This takes care of removing `resource_map_pid` from `parent_child_pids` if it's referenced.  I had to place it here because the `duped` check will catch it also.  I tested it, but if you'd like I can also write a unit test for this.  

Regarding updating the documentation: I see a few `param` descriptions that could be a little more clear, but wondering if there's a specific section you had in mind?  

I was also wondering what you thought about making the parent arguments aside from `parent_resource_map` optional, and using `get_package` to populate the rest of the arguments if `parent_resource_map` is populated?  