### PR TITLE
fixed bug in test code that prevents environment from being loaded

### DIFF
--- a/tests/testthat/test_dataone.R
+++ b/tests/testthat/test_dataone.R
@@ -1,6 +1,6 @@
 context("dataone")
 
-node <- env_load()$node
+node <- env_load()$mn
 
 test_that("permissions can be checked", {
   if (!is_token_set(node)) {


### PR DESCRIPTION
small change here - even if a token is set, the tests in this file will not run because there is no `env$node` object