### PR TITLE
publish_update unit test and docs 

### DIFF
--- a/R/editing.R
+++ b/R/editing.R
@@ -226,10 +226,10 @@ update_object <- function(mn, pid, path, format_id=NULL, new_pid=NULL, sid=NULL)
 #' @param data_pids (character)  PID(s) of data objects that will go in the updated package.
 #' @param identifier (character) Manually specify the identifier for the new metadata object.
 #' @param use_doi (logical) Generate and use a DOI as the identifier for the updated metadata object.
-#' @param parent_resmap_pid  (character)  Optional. PID of a parent package to be updated.
-#' @param parent_metadata_pid (character)  Optional. Identifier for the metadata document of the parent package.
-#' @param parent_data_pids (character)  Optional. Identifier for the data objects of the parent package.
-#' @param parent_child_pids (character) Optional. Resource map identifier(s) of child packages in the parent package.
+#' @param parent_resmap_pid  (character)  Optional. PID of a parent package to be updated. Not optional if a parent package exists.
+#' @param parent_metadata_pid (character)  Optional. Identifier for the metadata document of the parent package. Not optional if a parent package exists.
+#' @param parent_data_pids (character)  Optional. Identifier for the data objects of the parent package. Not optional if the parent package contains data objects.
+#' @param parent_child_pids (character) Optional. Resource map identifier(s) of child packages in the parent package.  \code{resource_map_pid} should not be included. Not optional if the parent package contains other child packages.
 #' @param child_pids (character) Optional. Child packages resource map PIDs.
 #' @param metadata_path (character) Optional. Path to a metadata file to update with. If this is not set, the existing metadata document will be used.
 #' @param public (logical) Optional. Make the update public. If FALSE, will set the metadata and resource map to private (but not the data objects).

--- a/tests/testthat/test_editing.R
+++ b/tests/testthat/test_editing.R
@@ -259,7 +259,7 @@ test_that("publishing an object with an invalid format ID fails", {
   expect_error(publish_object(mn, tmp_path, "asdf/asdf"))
 })
 
-test_that("publish_update removes the target package from 'parent_parent_pids' argument", {
+test_that("publish_update removes 'resource_map_pid' from 'parent_child_pids' argument", {
   if (!is_token_set(mn)) {
     skip("No token set. Skipping test.")
   }

--- a/tests/testthat/test_editing.R
+++ b/tests/testthat/test_editing.R
@@ -258,3 +258,33 @@ test_that("publishing an object with an invalid format ID fails", {
 
   expect_error(publish_object(mn, tmp_path, "asdf/asdf"))
 })
+
+test_that("publish_update removes the target package from 'parent_parent_pids' argument", {
+  if (!is_token_set(mn)) {
+    skip("No token set. Skipping test.")
+  }
+
+  parent <- create_dummy_package(mn)
+  child <- create_dummy_package(mn)
+
+  # Nest packages
+  parent["resource_map"] <- update_resource_map(mn,
+                                                parent$resource_map,
+                                                parent$metadata,
+                                                parent$data,
+                                                child$resource_map,
+                                                check_first = F)
+
+  # Updating parent incorrectly should still run (with parent resource_map listed in 'parent_parent_pids')
+  child <- publish_update(mn,
+                           child$metadata,
+                           child$resource_map,
+                           child$data,
+                           parent_resmap_pid = parent$resource_map,
+                           parent_metadata_pid = parent$metadata,
+                           parent_data_pids = parent$data,
+                           parent_child_pids = child$resource_map, check_first = F)
+  parent <- get_package(mn, child$parent_resource_map)
+
+  expect_equal(child$resource_map, parent$child_packages)
+})


### PR DESCRIPTION
Resolve #36 

I noticed that this was still open.  Added a unit test to test that `publish_update` removes `resource_map_pid` from the `parent_child_pids` argument, if it's incorrectly included.  Also updated the four "parent" `@param` definitions in the documentation.  