### PR TITLE
added ... to `create_resource_map`

### DIFF
--- a/R/editing.R
+++ b/R/editing.R
@@ -545,6 +545,7 @@ publish_update <- function(mn,
 #' @param check_first (logical) Optional. Whether to check the PIDs passed in as
 #'   aruments exist on the MN before continuing. This speeds up the function,
 #'   especially when `data_pids` has many elements.
+#' @param ... Additional arguments that can be passed into \code{\link{publish_object}}
 #'
 #' @return (character) The created resource map's PID
 #' @export
@@ -563,9 +564,10 @@ publish_update <- function(mn,
 #'}
 create_resource_map <- function(mn,
                                 metadata_pid,
-                                data_pids=NULL,
-                                child_pids=NULL,
-                                check_first=TRUE) {
+                                data_pids = NULL,
+                                child_pids = NULL,
+                                check_first = TRUE,
+                                ...) {
   stopifnot(is(mn, "MNode"))
   stopifnot(is.character(metadata_pid),
             nchar(metadata_pid) > 0)
@@ -591,7 +593,8 @@ create_resource_map <- function(mn,
   actual <- publish_object(mn,
                            path,
                            pid,
-                           format_id = "http://www.openarchives.org/ore/terms")
+                           format_id = "http://www.openarchives.org/ore/terms",
+                           ...)
 
   stopifnot(pid == actual)
 

--- a/man/create_resource_map.Rd
+++ b/man/create_resource_map.Rd
@@ -5,7 +5,7 @@
 \title{Create a resource map Object on a Member Node.}
 \usage{
 create_resource_map(mn, metadata_pid, data_pids = NULL, child_pids = NULL,
-  check_first = TRUE)
+  check_first = TRUE, ...)
 }
 \arguments{
 \item{mn}{(MNode) The Member Node}
@@ -22,6 +22,8 @@ nested under the package.}
 \item{check_first}{(logical) Optional. Whether to check the PIDs passed in as
 aruments exist on the MN before continuing. This speeds up the function,
 especially when `data_pids` has many elements.}
+
+\item{...}{Additional arguments that can be passed into \code{\link{publish_object}}}
 }
 \value{
 (character) The created resource map's PID

--- a/man/eml_project.Rd
+++ b/man/eml_project.Rd
@@ -9,7 +9,7 @@ eml_project(title, personnelList, abstract = NULL, funding = NULL,
   relatedProject = NULL)
 }
 \arguments{
-\item{title}{(character) Title of the project (Required).}
+\item{title}{(character) Title of the project (Required). May have multiple titles.}
 
 \item{personnelList}{(list of personnel) Personnel involved with the project.}
 
@@ -34,7 +34,7 @@ fully fleshed out. Need to pass these objects in directly if you want to use
 them.
 }
 \examples{
-proj <- eml_project("Some title",
+proj <- eml_project(c("Some title", "A second title if needed"),
            c(eml_personnel("Bryce", "Mecum", role = "principalInvestigator")),
            c("Abstract paragraph 1", "Abstract paragraph 2"),
            "Funding Agency: Award Number 12345")

--- a/man/publish_update.Rd
+++ b/man/publish_update.Rd
@@ -27,13 +27,13 @@ publish_update(mn, metadata_pid, resource_map_pid, data_pids = NULL,
 
 \item{use_doi}{(logical) Generate and use a DOI as the identifier for the updated metadata object.}
 
-\item{parent_resmap_pid}{(character)  Optional. PID of a parent package to be updated.}
+\item{parent_resmap_pid}{(character)  Optional. PID of a parent package to be updated. Not optional if a parent package exists.}
 
-\item{parent_metadata_pid}{(character)  Optional. Identifier for the metadata document of the parent package.}
+\item{parent_metadata_pid}{(character)  Optional. Identifier for the metadata document of the parent package. Not optional if a parent package exists.}
 
-\item{parent_data_pids}{(character)  Optional. Identifier for the data objects of the parent package.}
+\item{parent_data_pids}{(character)  Optional. Identifier for the data objects of the parent package. Not optional if the parent package contains data objects.}
 
-\item{parent_child_pids}{(character) Optional. Resource map identifier(s) of child packages in the parent package.}
+\item{parent_child_pids}{(character) Optional. Resource map identifier(s) of child packages in the parent package.  \code{resource_map_pid} should not be included. Not optional if the parent package contains other child packages.}
 
 \item{public}{(logical) Optional. Make the update public. If FALSE, will set the metadata and resource map to private (but not the data objects).
 This applies to the new metadata PID and its resource map and data object.


### PR DESCRIPTION
This allows for arguments such as `public = FALSE` to be passed into `create_resource_map`, which is a bug that @areevesman brought up on Slack.

We can also take the additional step of defaulting to `public = FALSE` in `publish_object` and `publish_update`. This can help minimize weird package viewing problems that occur when a public package becomes private and then public again (@jagoldstein).