### PR TITLE
Reduce dependencies on ncdf4 and yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ r:
   - release
   - devel
 sudo: false
+env:
+  - _R_CHECK_FORCE_SUGGESTS_=0
 cache: packages
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ r:
   - oldrel
   - release
   - devel
+r_packages: ncdf4
 sudo: false
-env:
-  - _R_CHECK_FORCE_SUGGESTS_=0
 cache: packages
 addons:
   apt:
+    update: true
     packages:
       - librdf0-dev
+      - libnetcdf-dev
+      - netcdf-bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,3 @@ addons:
   apt:
     packages:
       - librdf0-dev
-      - libnetcdf-dev
-      - r-cran-ncdf4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,6 @@ Depends:
     R (>= 3.2.3)
 Imports:
     digest,
-    dplyr,
     dataone,
     datapack,
     EML,
@@ -30,6 +29,7 @@ Imports:
 License: MIT + file LICENSE
 LazyData: true
 Suggests:
+    dplyr,
     testthat,
     humaniformat,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,12 +21,10 @@ Imports:
     EML,
     httr,
     methods,
-    ncdf4,
     stringr,
     stringi,
     tools,
     uuid,
-    yaml,
     xml2,
     XML
 License: MIT + file LICENSE
@@ -35,7 +33,9 @@ Suggests:
     testthat,
     humaniformat,
     knitr,
+    ncdf4,
     rmarkdown,
+    yaml,
     xslt
 RoxygenNote: 6.0.1
 VignetteBuilder: knitr

--- a/R/attributes.R
+++ b/R/attributes.R
@@ -12,6 +12,12 @@
 get_ncdf4_attributes <- function(nc) {
   stopifnot(is(nc, "ncdf4") || file.exists(nc))
 
+  if (!requireNamespace("ncdf4")) {
+    stop(call. = FALSE, 
+         "The package 'ncdf4' must be installed to run this function. ",
+         "Please install it and try again.")
+  }
+  
   # Read the file in if `nc` is a character vector
   if (is.character(nc)) {
     nc <- ncdf4::nc_open(nc)

--- a/R/environment.R
+++ b/R/environment.R
@@ -38,6 +38,12 @@ env_get <- function() {
 #'
 #'
 env_load <- function(name=NULL, path=NULL, skip_mn=FALSE) {
+  if (!requireNamespace("yaml")) {
+    stop(call. = FALSE, 
+         "The package 'yaml' must be installed to run this function. ",
+         "Please install it and try again.")
+  }
+
   # Determine the environment to load
   if (is.null(name)) {
     name <- env_get()

--- a/R/util.R
+++ b/R/util.R
@@ -109,6 +109,12 @@ get_netcdf_format_id <- function(path) {
             nchar(path) > 0,
             file.exists(path))
 
+  if (!requireNamespace("ncdf4")) {
+    stop(call. = FALSE, 
+         "The package 'ncdf4' must be installed to run this function. ",
+         "Please install it and try again.")
+  }
+
   # Try to open the file, capturing errors
   cdf_file <- try({
     ncdf4::nc_open(path)


### PR DESCRIPTION
@isteves helpfully noted that the Travis CI builds started failing a while ago in https://github.com/NCEAS/arcticdatautils/issues/86. The failures indicate issues with Ubuntu PPAs and nothing to do with our tools. Though this happened around the time R 3.5.0 was released, which is a backwards incompatible R release indue to the introduction of ALTREP. This is:

1. My attempt to fix that so all the Travis builds pass
2. Reduce the deps arcticdatautils requires to install. ncdf4 and yaml are not packages that _need_ to be installed to get started using it so they should be in Suggests