### PR TITLE
try installing ncdf4 from CRAN?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ addons:
     packages:
       - librdf0-dev
       - libnetcdf-dev
+      - netcdf-bin


### PR DESCRIPTION
Most debian binaries haven't been rebuilt yet for R 3.5.0.  Better to install from CRAN?
Let's see what travis thinks...