### PR TITLE
Publish update checks

### DIFF
--- a/R/editing.R
+++ b/R/editing.R
@@ -311,6 +311,18 @@ publish_update <- function(mn,
     stopifnot(all(is.character(parent_child_pids)))
   }
 
+  # Check that resource_map_pid, and metadata_pid are the current versions
+  meta_versions <- get_all_versions(mn, metadata_pid)
+  current_meta_version <- tail(metadata_versions, 1)
+  if (metadata_pid != current_meta_version) {
+    stop("metadata_pid is already obsoleted by: ", current_meta_version)
+  }
+  rm_versions <- get_all_versions(mn, resource_map_pid)
+  current_rm_version <- tail(rm_versions, 1)
+  if (resource_map_pid != current_rm_version) {
+    stop("resource_map_pid is already obsoleted by: ", current_rm_version)
+  }
+
   # Check to see if the obsoleted package is in the list of parent_child_pids
   # If it is notify the user and remove it from the list
   if (resource_map_pid %in% parent_child_pids) {

--- a/R/editing.R
+++ b/R/editing.R
@@ -311,16 +311,6 @@ publish_update <- function(mn,
     stopifnot(all(is.character(parent_child_pids)))
   }
 
-  # Check that resource_map_pid, and metadata_pid are the current versions
-  meta_obsoletedBy <- dataone::getSystemMetadata(mn, metadata_pid)@obsoletedBy
-  if (!is.na(meta_obsoletedBy)) {
-    stop("metadata_pid is already obsoleted by: ", meta_obsoletedBy)
-  }
-  rm_obsoletedBy <- dataone::getSystemMetadata(mn, resource_map_pid)@obsoletedBy
-  if (!is.na(rm_obsoletedBy)) {
-    stop("resource_map_pid is already obsoleted by: ", rm_obsoletedBy)
-  }
-
   # Check to see if the obsoleted package is in the list of parent_child_pids
   # If it is notify the user and remove it from the list
   if (resource_map_pid %in% parent_child_pids) {
@@ -364,6 +354,16 @@ publish_update <- function(mn,
       stopifnot(object_exists(mn, parent_data_pids))
     if (!is.null(parent_child_pids))
       stopifnot(object_exists(mn, parent_child_pids))
+  }
+
+  # Check that resource_map_pid, and metadata_pid are the current versions
+  meta_obsoletedBy <- dataone::getSystemMetadata(mn, metadata_pid)@obsoletedBy
+  if (!is.na(meta_obsoletedBy)) {
+    stop("metadata_pid is already obsoleted by: ", meta_obsoletedBy)
+  }
+  rm_obsoletedBy <- dataone::getSystemMetadata(mn, resource_map_pid)@obsoletedBy
+  if (!is.na(rm_obsoletedBy)) {
+    stop("resource_map_pid is already obsoleted by: ", rm_obsoletedBy)
   }
 
   # Prepare the response object

--- a/R/editing.R
+++ b/R/editing.R
@@ -312,15 +312,13 @@ publish_update <- function(mn,
   }
 
   # Check that resource_map_pid, and metadata_pid are the current versions
-  meta_versions <- get_all_versions(mn, metadata_pid)
-  current_meta_version <- tail(metadata_versions, 1)
-  if (metadata_pid != current_meta_version) {
-    stop("metadata_pid is already obsoleted by: ", current_meta_version)
+  meta_obsoletedBy <- dataone::getSystemMetadata(mn, metadata_pid)@obsoletedBy
+  if (!is.na(meta_obsoletedBy)) {
+    stop("metadata_pid is already obsoleted by: ", meta_obsoletedBy)
   }
-  rm_versions <- get_all_versions(mn, resource_map_pid)
-  current_rm_version <- tail(rm_versions, 1)
-  if (resource_map_pid != current_rm_version) {
-    stop("resource_map_pid is already obsoleted by: ", current_rm_version)
+  rm_obsoletedBy <- dataone::getSystemMetadata(mn, resource_map_pid)@obsoletedBy
+  if (!is.na(rm_obsoletedBy)) {
+    stop("resource_map_pid is already obsoleted by: ", rm_obsoletedBy)
   }
 
   # Check to see if the obsoleted package is in the list of parent_child_pids

--- a/tests/testthat/test_editing.R
+++ b/tests/testthat/test_editing.R
@@ -288,3 +288,15 @@ test_that("publish_update removes 'resource_map_pid' from 'parent_child_pids' ar
 
   expect_equal(child$resource_map, parent$child_packages)
 })
+
+test_that("publish_update errors if the non-current resource map or metadata pid is provided", {
+  if (!is_token_set(mn)) {
+    skip("No token set. Skipping test.")
+  }
+
+  pkg1 <- create_dummy_package(mn)
+  pkg2 <- publish_update(mn, pkg1$metadata, pkg1$resource_map, pkg1$data)
+
+  expect_error(publish_update(mn, pkg1$metadata, pkg2$resource_map, pkg2$data))
+  expect_error(publish_update(mn, pkg2$metadata, pkg1$resource_map, pkg2$data))
+})


### PR DESCRIPTION
Added `publish_update` argument checks + unit tests to verify that the `resource_map_pid` and `metadata_pid` are current.  Resolve #99 