### PR TITLE
fixed bug in pid_to_eml_physical

### DIFF
--- a/R/eml.R
+++ b/R/eml.R
@@ -41,7 +41,6 @@ pid_to_eml_entity <- function(mn,
                               "otherEntity"))
 
   systmeta <- getSystemMetadata(mn, pid)
-  physical <- sysmeta_to_eml_physical(systmeta)
 
   # Create entity
   entity <- new(entityType,
@@ -128,6 +127,7 @@ pid_to_eml_physical <- function(mn, pids) {
   stopifnot(is(mn, "MNode"))
   stopifnot(is.character(pids),
             all(nchar(pids)) > 0)
+  names(pids) <- ''  # Named inputs produce a named output list - which is invalid in EML
 
   sysmeta <- lapply(pids, function(pid) { getSystemMetadata(mn, pid) })
   sysmeta_to_eml_physical(sysmeta)
@@ -994,6 +994,8 @@ eml_add_entities <- function(doc,
 #' \code{FALSE} reduces execution time by ~ 50 percent.
 #'
 #' @author Dominic Mullen dmullen17@@gmail.com
+#'
+#' @importFrom magrittr '%>%'
 #'
 #' @export
 #'


### PR DESCRIPTION
Found a bug with `pid_to_eml_physical`.  Named inputs produce a named list - an output that EML doesn't expect and finds invalid.  This is a fairly common error because named lists of data pids from `get_package(mn, rm, file.names=TRUE)` are used in processing all the time.  