### PR TITLE
eml_set_shared_attributes

### DIFF
--- a/R/eml.R
+++ b/R/eml.R
@@ -1150,8 +1150,16 @@ which_in_eml <- function(eml_list, element, test) {
 #' eml@@dataset@@contact[[1]])
 #'
 #' # This is also useful when we want to set references to a subset of 'dataTable' or 'otherEntity' objects
-#'
-#'
+#' # Add a few more objects to illustrate the use
+#' eml@@dataset@@dataTable[[3]] <- eml@@dataset@@dataTable[[1]]
+#' eml@@dataset@@dataTable[[4]] <- eml@@dataset@@dataTable[[1]]
+#' # Add references to the second and third elements
+#' for (i in 2:3) {
+#'     eml@@dataset@@dataTable[[i]] <- eml_set_reference(eml@@dataset@@dataTable[[1]],
+#'                                                       eml@@dataset@@dataTable[[1]])
+#' }
+#' # If we print the entire 'dataTable' list we see elements 2 and 3 have references while 4 does not.
+#' eml@@dataset@@dataTable
 #' }
 eml_set_reference <- function(element_to_reference, element_to_replace) {
   if (length(element_to_reference@id) == 0) {

--- a/R/eml.R
+++ b/R/eml.R
@@ -1124,3 +1124,93 @@ which_in_eml <- function(eml_list, element, test) {
 
   return(location)
 }
+
+
+#' Set a reference to an EML object
+#'
+#' This function creates a new object with the same class as \code{element_to_replace}
+#' using a reference to \code{element_to_reference}
+#'
+#' @param element_to_reference (S4) An EML object to reference
+#' @param element_to_replace (S4) An EML object to replace with a reference
+#'
+#' @author Dominic Mullen dmullen17@@gmail.com
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#'
+#' cn <- dataone::CNode('PROD')
+#' adc <- dataone::getMNode(cn,'urn:node:ARCTIC')
+#' eml <- EML::read_eml(dataone::getObject(adc, 'doi:10.18739/A2S17SS1M'))
+#'
+#' # Set the first contact as a reference to the first creator
+#' eml@@dataset@@contact[[1]] <- eml_set_reference(eml@@dataset@@creator[[1]],
+#' eml@@dataset@@contact[[1]])
+#'
+#' # This is also useful when we want to set references to a subset of 'dataTable' or 'otherEntity' objects
+#'
+#'
+#' }
+eml_set_reference <- function(element_to_reference, element_to_replace) {
+  if (length(element_to_reference@id) == 0) {
+    stop('No id detected at element_to_reference@id. Please add an id in order to use references.')
+  }
+  id <- element_to_reference@id
+  class <- class(element_to_replace)[1]
+  element_to_replace <- new(class, reference = id)
+  return(element_to_replace)
+}
+
+
+#' Set shared attribute references
+#'
+#' This function sets shared attributes using the attributes of the first \code{type}
+#' selected and creates references for all remaining objects of equivalent \code{type}.
+#'
+#' @param eml (S4) An EML S4 object
+#' @param attributeList (S4) Optional. An EML attributeList object. If not provided then it will default to the attributeList of the first \code{type} element
+#' @param type (character) Optional. Specifies whether to replace 'dataTable' or 'otherEntity' attributeList objects with references. Defaults to 'dataTable'
+#'
+#' @author Dominic Mullen dmullen17@@gmail.com
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#'
+#' cn <- dataone::CNode('PROD')
+#' adc <- dataone::getMNode(cn,'urn:node:ARCTIC')
+#' eml <- EML::read_eml(dataone::getObject(adc, 'doi:10.18739/A2S17SS1M'))
+#' atts <- EML::set_attributes(EML::get_attributes(eml@@dataset@@dataTable[[1]]@@attributeList)$attributes)
+#'
+#' eml <- eml_set_shared_attributes(eml, atts, type = 'dataTable')
+#'
+#' }
+eml_set_shared_attributes <- function(eml, attributeList = NULL, type = 'dataTable') {
+  stopifnot(methods::is(eml, 'eml'))
+  if(!is.null(attributeList)) {
+    stopifnot(methods::is(attributeList, 'attributeList'))
+  }
+  stopifnot(type %in% c('dataTable', 'otherEntity'))
+
+  x <- slot(eml@dataset, type)
+  n <- length(x)
+  if (n <= 1) {
+    stop('1 or fewer entities') # add message
+  }
+
+  # If a new attributeList is provided set it
+  if (!is.null(attributeList)) {
+    x[[1]]@attributeList <- attributeList
+  }
+  x[[1]]@id <- new('xml_attribute', uuid::UUIDgenerate(TRUE))
+  # Apply references to all other elements
+  for (i in 2:n) {
+    x[[i]] <- eml_set_reference(x[[1]], x[[i]])
+  }
+
+  slot(eml@dataset, type) <- x
+  return(eml)
+}

--- a/R/eml.R
+++ b/R/eml.R
@@ -1165,7 +1165,7 @@ eml_set_reference <- function(element_to_reference, element_to_replace) {
   if (length(element_to_reference@id) == 0) {
     stop('No id detected at element_to_reference@id. Please add an id in order to use references.')
   }
-  id <- element_to_reference@id
+  id <- element_to_reference@id[1]
   class <- class(element_to_replace)[1]
   element_to_replace <- new(class, reference = id)
   return(element_to_replace)


### PR DESCRIPTION
Added two functions for setting references.  Resolve #31  

eml_set_shared_attributes - sets shared attributes for a list of `dataTable` or `otherEntity` objects.  Can accept an `attributeList` as an input, otherwise defaults to the `attributeList` of the first object. 

eml_set_reference - originally intended as a helper function but it should have some use cases - specifically for adding references to `creator` / `contact` or a subset of `dataTable`/ `otherEntity`.   