### PR TITLE
Updated `eml_party` args to accept multiple inputs

### DIFF
--- a/man/eml_contact.Rd
+++ b/man/eml_contact.Rd
@@ -17,4 +17,7 @@ See \code{\link{eml_party}} for details.
 }
 \examples{
 eml_contact("test", "user", email = "test@user.com")
+eml_creator("creator", "Bryce", "Mecum", userId = "https://orcid.org/0000-0002-0381-3766")
+eml_creator("creator", c("Dominic", "'Dom'"), "Mullen", c("NCEAS", "UCSB"),
+            c("Data Scientist", "Programmer"))
 }

--- a/man/eml_creator.Rd
+++ b/man/eml_creator.Rd
@@ -17,4 +17,7 @@ See \code{\link{eml_party}} for details.
 }
 \examples{
 eml_creator("test", "user", email = "test@user.com")
+eml_creator("creator", "Bryce", "Mecum", userId = "https://orcid.org/0000-0002-0381-3766")
+eml_creator("creator", c("Dominic", "'Dom'"), "Mullen", c("NCEAS", "UCSB"),
+            c("Data Scientist", "Programmer"))
 }

--- a/man/eml_party.Rd
+++ b/man/eml_party.Rd
@@ -44,4 +44,6 @@ The \code{userId} argument assumes an ORCID so be sure to adjust for that.
 \examples{
 eml_party("creator", "Test", "User")
 eml_party("creator", "Bryce", "Mecum", userId = "https://orcid.org/0000-0002-0381-3766")
+eml_party("creator", c("Dominic", "'Dom'"), "Mullen", c("NCEAS", "UCSB"),
+          c("Data Scientist", "Programmer"))
 }

--- a/man/eml_set_reference.Rd
+++ b/man/eml_set_reference.Rd
@@ -26,14 +26,15 @@ eml <- EML::read_eml(dataone::getObject(adc, 'doi:10.18739/A2S17SS1M'))
 eml@dataset@contact[[1]] <- eml_set_reference(eml@dataset@creator[[1]],
 eml@dataset@contact[[1]])
 
-# This is also useful when we want to set references to a subset of 'dataTable' or 'otherEntity' objects
-# Add a few more objects to illustrate the use
+# This is also useful when we want to set references to a subset of 'dataTable'
+  or 'otherEntity' objects
+# Add a few more objects first to illustrate the use:
 eml@dataset@dataTable[[3]] <- eml@dataset@dataTable[[1]]
 eml@dataset@dataTable[[4]] <- eml@dataset@dataTable[[1]]
-# Add references to the second and third elements
+# Add references to the second and third elements only (not the 4th):
 for (i in 2:3) {
-    eml@dataset@dataTable[[i]] <- eml_set_reference(eml@dataset@dataTable[[1]],
-                                                      eml@dataset@dataTable[[1]])
+    eml@dataset@dataTable[[i]]@attributeList <- eml_set_reference(eml@dataset@dataTable[[1]]@attributeList,
+                                                      eml@dataset@dataTable[[i]]@attributeList)
 }
 # If we print the entire 'dataTable' list we see elements 2 and 3 have references while 4 does not.
 eml@dataset@dataTable

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -277,6 +277,7 @@ test_that('eml_set_reference sets a reference', {
   doc@dataset@contact[[1]] <- eml_set_reference(doc@dataset@creator[[1]], doc@dataset@contact[[1]])
 
   expect_equal(doc@dataset@creator[[1]]@id[1], doc@dataset@contact[[1]]@references[1])
+  expect_true(EML::eml_validate(doc))
 })
 
 test_that('eml_set_shared_attributes creates shared attribute references', {
@@ -299,4 +300,15 @@ test_that('eml_set_shared_attributes creates shared attribute references', {
   doc <- eml_set_shared_attributes(doc)
 
   expect_equal(doc@dataset@dataTable[[1]]@id[1], doc@dataset@dataTable[[2]]@references[1])
+  expect_true(EML::eml_validate(doc))
+})
+
+test_that('eml_party creates multiple giveName, organizationName, and positionName fields', {
+  creator <- eml_party('creator', c('John', 'and Jack'), 'Smith', c('NCEAS', 'UCSB'),
+                       c('Programmers', 'brothers'))
+
+  expect_is(creator, "creator")
+  expect_equal(unlist(EML::eml_get(creator, 'givenName')), c('John', 'and Jack'))
+  expect_equal(unlist(EML::eml_get(creator, 'organizationName')), c('NCEAS', 'UCSB'))
+  expect_equal(unlist(EML::eml_get(creator, 'positionName')), c('Programmers', 'brothers'))
 })


### PR DESCRIPTION
- `eml_party` now accepts multiple `organization` and `position` inputs. 
- fixed a bug in `eml_set_shared_attributes` that set the entire `dataTable` or `otherEntity` object to a reference when we only want to the `attributeList` to get replaced with a reference 
- updated some typos in documentation / added a few more examples