### PR TITLE
set_public_read_all_versions function

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -1057,3 +1057,38 @@ show_indexing_status <- function(mn, pids) {
 
   close(pb)
 }
+
+#' Set public READ access on all versions of PIDs in data package.
+#'
+#' Set public READ access on all versions of PIDs in data package.
+#'
+#' @param mn (MNode) The Member Node to query.
+#' @param resource_map_pid (character) The resource map identifier (PID).
+#'
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' cn_staging <- CNode('STAGING')
+#' adc_test <- getMNode(cn_staging,'urn:node:mnTestARCTIC')
+#' # Create a dummy package then create another version with 'publish_update()'
+#' pkg <- create_dummy_package(adc_test)
+#' remove_public_read(mn, unlist(pkg))
+#' pkg_v2 <- publish_update(adc_test, pkg$metadata, pkg$resource_map, pkg$data, public = FALSE)
+#' # Set public read on all versions
+#' set_public_read_all_versions(adc_test, pkg$resource_map)
+#' }
+set_public_read_all_versions <- function(mn, resource_map_pid) {
+  stopifnot(is(mn, 'MNode'))
+  stopifnot(is_token_set(mn))
+  stopifnot(is.character(resource_map_pid))
+  stopifnot(arcticdatautils:::is_resource_map(mn, resource_map_pid))
+
+  versions <- get_all_versions(mn, resource_map_pid)
+  pids <- map(versions, get_package, node = mn) %>%
+    unlist() %>%
+    unique()
+  set_public_read(mn, pids)
+
+  return(invisible())
+}

--- a/R/util.R
+++ b/R/util.R
@@ -1082,10 +1082,10 @@ set_public_read_all_versions <- function(mn, resource_map_pid) {
   stopifnot(is(mn, 'MNode'))
   stopifnot(is_token_set(mn))
   stopifnot(is.character(resource_map_pid))
-  stopifnot(arcticdatautils:::is_resource_map(mn, resource_map_pid))
+  stopifnot(is_resource_map(mn, resource_map_pid))
 
   versions <- get_all_versions(mn, resource_map_pid)
-  pids <- map(versions, get_package, node = mn) %>%
+  pids <- lapply(versions, get_package, node = mn) %>%
     unlist() %>%
     unique()
   set_public_read(mn, pids)

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -18,7 +18,7 @@ test_that("paths can be joined", {
 
 test_that('we can set public READ on all versions of a data package', {
   cn <- CNode('STAGING')
-  mn <- getMNode(mn,'urn:node:mnTestARCTIC')
+  mn <- getMNode(cn,'urn:node:mnTestARCTIC')
   if (!is_token_set(mn)) {
     skip("No token set. Skipping test.")
   }

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -15,3 +15,20 @@ test_that("paths can be joined", {
   # Other tests
   expect_equal(path_join("~/src/arcticdata./inst/asdf"), "~/src/arcticdata/inst/asdf")
 })
+
+test_that('we can set public READ on all versions of a data package', {
+  cn <- CNode('STAGING')
+  mn <- getMNode(mn,'urn:node:mnTestARCTIC')
+  if (!is_token_set(mn)) {
+    skip("No token set. Skipping test.")
+  }
+
+  pkg <- create_dummy_package(mn)
+  remove_public_read(mn, unlist(pkg))
+  pkg_v2 <- publish_update(mn, pkg$metadata, pkg$resource_map, pkg$data, public = FALSE)
+  # Set public read on all versions
+  set_public_read_all_versions(mn, pkg$resource_map)
+  pids <- c(unlist(pkg), unlist(pkg_v2))
+
+  expect_true(all(is_public_read(mn, pids)))
+})

--- a/tests/testthat/test_util.R
+++ b/tests/testthat/test_util.R
@@ -17,8 +17,8 @@ test_that("paths can be joined", {
 })
 
 test_that('we can set public READ on all versions of a data package', {
-  cn <- CNode('STAGING')
-  mn <- getMNode(cn,'urn:node:mnTestARCTIC')
+  cn <- dataone::CNode('STAGING')
+  mn <- dataone::getMNode(cn,'urn:node:mnTestARCTIC')
   if (!is_token_set(mn)) {
     skip("No token set. Skipping test.")
   }


### PR DESCRIPTION
Added a function that gets all versions of a package and sets public read on the objects.  This is a pretty small addition but an improvement to our workflow for updating data packages.  Per the ADC call on 11/9 all versions of a package should be public after it's finalized with a DOI