### PR TITLE
update `pid_to`... functions

### DIFF
--- a/R/eml.R
+++ b/R/eml.R
@@ -203,68 +203,6 @@ get_doc_id <- function(sysmeta) {
 }
 
 
-#' Add a methods step
-#'
-#' Add a methods step to an EML document.
-#'
-#' @param doc (eml) The EML document to add the method step to.
-#' @param title (character) The title of the method step.
-#' @param description (character) The description of the method.
-#'
-#' @return (eml) The modified EML document.
-#'
-#' @export
-#'
-#' @examples
-#' \dontrun{
-#' eml <- read_eml("~/Documents/metadata.xml")
-#' eml <- add_methods_step(eml, "Field Sampling", "Samples were
-#' collected using a niskin water sampler.")
-#' }
-add_methods_step <- function(doc, title, description) {
-  stopifnot(is(doc, "eml"))
-  stopifnot(is(doc@dataset, "dataset"))
-  stopifnot(is.character(title),
-            nchar(title) > 0)
-  stopifnot(is.character(description),
-            nchar(description) > 0)
-
-  new_step <- new("methodStep",
-                  description  = new("description",
-                                     section = new("section", list(newXMLNode("title", title),
-                                                                   newXMLNode("para", description)))))
-
-  doc@dataset@methods@methodStep[[length(doc@dataset@methods@methodStep) + 1]] <- new_step
-
-  doc
-}
-
-
-#' Clear all methods
-#'
-#' Clear all methods from an EML document.
-#'
-#' @param doc (eml) The document to clear methods from.
-#'
-#' @return (eml) The modified EML document.
-#'
-#' @export
-#'
-#' @examples
-#' \dontrun{
-#' eml <- read_eml("~/Documents/metadata.xml")
-#' eml <- clear_methods(eml)
-#' }
-clear_methods <- function(doc) {
-  stopifnot(is(doc, "eml"))
-
-  # Clear the methods out
-  doc@dataset@methods <- new("MethodsType")
-
-  doc
-}
-
-
 #' Create an EML party
 #'
 #' You will usually want to use the high-level functions such as

--- a/R/eml.R
+++ b/R/eml.R
@@ -24,7 +24,7 @@
 #' }
 pid_to_eml_entity <- function(mn,
                               pid,
-                              entityType = "otherEntity",
+                              entity_type = "otherEntity",
                               ...) {
 
   stopifnot(is(mn, "MNode"))
@@ -32,7 +32,7 @@ pid_to_eml_entity <- function(mn,
             nchar(pid) > 0,
             length(pid) == 1)
 
-  stopifnot(entityType %in% c("dataTable",
+  stopifnot(entity_type %in% c("dataTable",
                               "spatialRaster",
                               "spatialVector",
                               "storedProcedure",
@@ -41,28 +41,28 @@ pid_to_eml_entity <- function(mn,
 
   systmeta <- getSystemMetadata(mn, pid)
 
-  if (entityType == "otherEntity"){
+  if (entity_type == "otherEntity"){
     entity <- eml$otherEntity(physical = pid_to_eml_physical(mn, pid), ...)
   }
-  else if (entityType == "dataTable"){
+  else if (entity_type == "dataTable"){
     entity <- eml$dataTable(physical = pid_to_eml_physical(mn, pid), ...)
   }
-  else if (entityType == "spatialRaster"){
+  else if (entity_type == "spatialRaster"){
     entity <- eml$spatialRaster(physical = pid_to_eml_physical(mn, pid), ...)
   }
-  else if (entityType == "spatialVector"){
+  else if (entity_type == "spatialVector"){
     entity <- eml$spatialVector(physical = pid_to_eml_physical(mn, pid), ...)
   }
-  else if (entityType == "storedProcedure"){
+  else if (entity_type == "storedProcedure"){
     entity <- eml$storedProcedure(physical = pid_to_eml_physical(mn, pid), ...)
   }
-  else if (entityType == "view"){
+  else if (entity_type == "view"){
     entity <- eml$view(physical = pid_to_eml_physical(mn, pid), ...)
   }
 
   # Set entity slots
   if (length(entity$id) == 0) {
-   # entity$id <- list(xml_attribute = systmeta@identifier)
+    # entity$id <- list(xml_attribute = systmeta@identifier)
     entity$id <- systmeta@identifier
   }
 
@@ -78,7 +78,7 @@ pid_to_eml_entity <- function(mn,
     }
   }
 
-  if (entityType == "otherEntity" && length(entity$entityType) == 0) {
+  if (entity_type == "otherEntity" && length(entity$entity_type) == 0) {
     entity$entityType <- "Other"
   }
 
@@ -151,8 +151,8 @@ sysmeta_to_eml_physical <- function(sysmeta) {
                          authMethod = x@checksumAlgorithm,
                          url = paste0("https://cn.dataone.org/cn/v2/resolve/", x@identifier))
 
-    phys$scope <- "document"
     phys$dataFormat <- eml$dataFormat(externallyDefinedFormat = list(formatName = x@formatId))
+
     phys
 }
 

--- a/R/eml.R
+++ b/R/eml.R
@@ -442,22 +442,16 @@ eml_individual_name <- function(given_names=NULL, sur_name) {
   stopifnot(is.character(sur_name) && nchar(sur_name) > 0)
 
   # Create <individualName>
-  indiv_name <- new("individualName")
+  indiv_name <- eml$individualName()
 
   if (!is.null(given_names)) {
     stopifnot(all(sapply(given_names, is.character)))
     stopifnot(all(lengths(given_names) > 0))
 
-    givens <- lapply(given_names, function(given_name) {
-      x <- new("givenName")
-      x@.Data <- given_name
-      x
-    })
-
-    indiv_name@givenName <- new("ListOfgivenName", givens)
+    indiv_name$givenName = given_names
   }
 
-  indiv_name@surName <- new("surName", .Data = sur_name)
+  indiv_name$surName <- sur_name
 
   indiv_name
 }

--- a/R/eml.R
+++ b/R/eml.R
@@ -97,9 +97,11 @@ pid_to_eml_physical <- function(mn, pids) {
             all(nchar(pids)) > 0)
   names(pids) <- ''  # Named inputs produce a named output list - which is invalid in EML
 
-  sysmeta <- lapply(pids, function(pid) { getSystemMetadata(mn, pid) })
+  #it really doesn't like this in a liset
+  #sysmeta <- lapply(pids, function(pid) { getSystemMetadata(mn, pid) })
+  sysmeta <- getSystemMetadata(mn, pids)
 
-  eml$physical(sysmeta_to_eml_physical(sysmeta))
+  sysmeta_to_eml_physical(sysmeta)
 }
 
 
@@ -126,8 +128,6 @@ pid_to_eml_physical <- function(mn, pids) {
 #' }
 sysmeta_to_eml_physical <- function(sysmeta) {
   work <- function(x) {
-    phys <- eml$physical()
-    phys$scope <- "document"
 
     if (is.na(x@fileName)) {
       ob_name <- "NA"
@@ -137,14 +137,13 @@ sysmeta_to_eml_physical <- function(sysmeta) {
 
 
     phys <- set_physical(objectName = ob_name,
-                         id = x@identifier,
                          size = format(x@size, scientific = FALSE),
                          sizeUnit = "bytes",
                          authentication = x@checksum,
                          authMethod = x@checksumAlgorithm,
                          url = paste0("https://cn.dataone.org/cn/v2/resolve/", x@identifier))
 
-
+    phys$scope <- "document"
     phys$dataFormat <- eml$dataFormat(externallyDefinedFormat = list(formatName = x@formatId))
 
     phys

--- a/R/eml.R
+++ b/R/eml.R
@@ -42,10 +42,22 @@ pid_to_eml_entity <- function(mn,
   systmeta <- getSystemMetadata(mn, pid)
 
   if (entityType == "otherEntity"){
-    entity <- eml$otherEntity(physical = pid_to_eml_physical(mn, pid))
+    entity <- eml$otherEntity(physical = pid_to_eml_physical(mn, pid), ...)
   }
   else if (entityType == "dataTable"){
-    entity <- eml$dataTable(physical = pid_to_eml_physical(mn, pid))
+    entity <- eml$dataTable(physical = pid_to_eml_physical(mn, pid), ...)
+  }
+  else if (entityType == "spatialRaster"){
+    entity <- eml$spatialRaster(physical = pid_to_eml_physical(mn, pid), ...)
+  }
+  else if (entityType == "spatialVector"){
+    entity <- eml$spatialVector(physical = pid_to_eml_physical(mn, pid), ...)
+  }
+  else if (entityType == "storedProcedure"){
+    entity <- eml$storedProcedure(physical = pid_to_eml_physical(mn, pid), ...)
+  }
+  else if (entityType == "view"){
+    entity <- eml$view(physical = pid_to_eml_physical(mn, pid), ...)
   }
 
   # Set entity slots

--- a/R/eml.R
+++ b/R/eml.R
@@ -29,7 +29,8 @@ pid_to_eml_entity <- function(mn,
 
   stopifnot(is(mn, "MNode"))
   stopifnot(is.character(pid),
-            nchar(pid) > 0)
+            nchar(pid) > 0,
+            length(pid) == 1)
 
   stopifnot(entityType %in% c("dataTable",
                               "spatialRaster",
@@ -87,19 +88,17 @@ pid_to_eml_entity <- function(mn,
 #'
 #' @examples
 #' \dontrun{
-#' # Generate EML physical objects for all the data in a package
-#' pkg <- get_package(mn, pid)
-#' pid_to_eml_physical(mn, pkg$data)
+#' # Generate EML physical sections for an object in a data package
+#' pid_to_eml_physical(mn, pid)
 #' }
-pid_to_eml_physical <- function(mn, pids) {
+pid_to_eml_physical <- function(mn, pid) {
   stopifnot(is(mn, "MNode"))
-  stopifnot(is.character(pids),
-            all(nchar(pids)) > 0)
-  names(pids) <- ''  # Named inputs produce a named output list - which is invalid in EML
+  stopifnot(is.character(pid),
+            all(nchar(pid)) > 0,
+            length(pid) == 1)
+  names(pid) <- ''  # Named inputs produce a named output list - which is invalid in EML
 
-  #it really doesn't like this in a liset
-  #sysmeta <- lapply(pids, function(pid) { getSystemMetadata(mn, pid) })
-  sysmeta <- getSystemMetadata(mn, pids)
+  sysmeta <- getSystemMetadata(mn, pid)
 
   sysmeta_to_eml_physical(sysmeta)
 }
@@ -119,15 +118,12 @@ pid_to_eml_physical <- function(mn, pids) {
 #'
 #' @examples
 #' \dontrun{
-#' # Generate EML physical objects for all the data in a package
-#' pkg <- get_package(mn, pid)
-#' sm <- lapply(pkg$data, function(pid) {
-#'   getSystemMetadata(mn, pid)
-#' })
+#' # Generate EML physical object from a system metadata object
+#' sm <- getSystemMetadata(mn, pid)
 #' sysmeta_to_eml_physical(sm)
 #' }
 sysmeta_to_eml_physical <- function(sysmeta) {
-  work <- function(x) {
+    stopifnot(is(sysmeta, "SystemMetadata"))
 
     if (is.na(x@fileName)) {
       ob_name <- "NA"
@@ -145,13 +141,7 @@ sysmeta_to_eml_physical <- function(sysmeta) {
 
     phys$scope <- "document"
     phys$dataFormat <- eml$dataFormat(externallyDefinedFormat = list(formatName = x@formatId))
-
     phys
-  }
-
-  if (!is(sysmeta, "list")) sysmeta <- list(sysmeta)
-
-  lapply(sysmeta, work)
 }
 
 

--- a/R/eml.R
+++ b/R/eml.R
@@ -247,51 +247,52 @@ eml_party <- function(type="associatedParty",
          "You must specify at least one of sur_name, organization, or position to make a valid creator")
   }
 
-  party <- new(type)
+  if (type == "creator"){
+    party <- eml$creator()
+  }
+  else if (type == "contact"){
+    party <- eml$creator()
+  }
+  else if (type == "associatedParty"){
+    party <- eml$creator()
+  }
+  else if (type == "metadataProvider"){
+    party <- eml$creator()
+  }
+  else if (type == "personnel"){
+    party <- eml$creator()
+  }
+
 
   # Individual Name
   if (!is.null(sur_name)) {
-    party@individualName <- c(eml_individual_name(given_names, sur_name))
+    party$individualName <- c(eml_individual_name(given_names, sur_name))
   }
 
   # Organization Name
   if (!is.null(organization)) {
-    party@organizationName <- new('ListOforganizationName', lapply(organization, function(x) {new('organizationName', .Data = x)}))
+    party$organizationName <- organization
   }
 
   # Position
   if (!is.null(position)) {
-    party@positionName <- new('ListOfpositionName', lapply(position, function(x) {new('positionName', .Data = x)}))
+    party$positionName <- position
   }
 
   # Email
   if (!is.null(email)) {
-    party@electronicMailAddress <- new("ListOfelectronicMailAddress", lapply(email, function(x) { new("electronicMailAddress", .Data = x )}))
+    party$electronicMailAddress <- email
   }
 
   # Address
   if (!is.null(address)) {
-    # Upgade to a ListOfaddress if needed
-    if (is(address, "address")) {
-      address <- c(address)
-    }
-
-    party@address <- address
+    # This crams the entire address into the delivery point...not ideal
+    party$address <- eml$address(address)
   }
 
   # Phone
   if (!is.null(phone)) {
-    # Upgrade to phone is needed
-    if (is.character(phone)) {
-      phone <- new("ListOfphone", lapply(phone, function(x) as(x, "phone")))
-    }
-
-    # Upgade to a ListOfphone if needed
-    if (is(phone, "phone")) {
-      phone <- c(phone)
-    }
-
-    party@phone <- phone
+    party$phone <- phone
   }
 
   # userId
@@ -301,7 +302,9 @@ eml_party <- function(type="associatedParty",
       warning(paste0("The provided `userId` of '", userId, "' does not look like an ORCID and the `userId` argument assumes the given `userId` is an ORCID. ORCIDs should be passed in like https://orcid.org/WWWW-XXXX-YYYY-ZZZZ."))
     }
 
-    party@userId <- c(new("userId", .Data = userId, directory = "https://orcid.org"))
+    party$userId <- eml$userId()
+    party$userId$userId <- userID
+    party$userId$directory = "https://orcid.org"
   }
 
   # Role
@@ -314,9 +317,7 @@ eml_party <- function(type="associatedParty",
 
     # If type is personnel, role needs to be ListOfrole, otherwise just role
     if (type == "personnel") {
-      party@role <- as(lapply(role, as, Class = "role"), "ListOfrole")
-    } else {
-      party@role <- as(role, "role")
+      party$role <- role
     }
   }
 

--- a/R/eml.R
+++ b/R/eml.R
@@ -41,24 +41,7 @@ pid_to_eml_entity <- function(mn,
 
   systmeta <- getSystemMetadata(mn, pid)
 
-  if (entity_type == "otherEntity"){
-    entity <- eml$otherEntity(physical = pid_to_eml_physical(mn, pid), ...)
-  }
-  else if (entity_type == "dataTable"){
-    entity <- eml$dataTable(physical = pid_to_eml_physical(mn, pid), ...)
-  }
-  else if (entity_type == "spatialRaster"){
-    entity <- eml$spatialRaster(physical = pid_to_eml_physical(mn, pid), ...)
-  }
-  else if (entity_type == "spatialVector"){
-    entity <- eml$spatialVector(physical = pid_to_eml_physical(mn, pid), ...)
-  }
-  else if (entity_type == "storedProcedure"){
-    entity <- eml$storedProcedure(physical = pid_to_eml_physical(mn, pid), ...)
-  }
-  else if (entity_type == "view"){
-    entity <- eml$view(physical = pid_to_eml_physical(mn, pid), ...)
-  }
+  entity <- eml[[entity_type]](physical = pid_to_eml_physical(mn, pid), ...)
 
   # Set entity slots
   if (length(entity$id) == 0) {
@@ -247,22 +230,7 @@ eml_party <- function(type="associatedParty",
          "You must specify at least one of sur_name, organization, or position to make a valid creator")
   }
 
-  if (type == "creator"){
-    party <- eml$creator()
-  }
-  else if (type == "contact"){
-    party <- eml$creator()
-  }
-  else if (type == "associatedParty"){
-    party <- eml$creator()
-  }
-  else if (type == "metadataProvider"){
-    party <- eml$creator()
-  }
-  else if (type == "personnel"){
-    party <- eml$creator()
-  }
-
+  party <- eml[[type]]()
 
   # Individual Name
   if (!is.null(sur_name)) {

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -104,7 +104,8 @@ test_that("a dataTable and otherEntity can be added from a pid", {
 
   data_path <- tempfile()
   writeLines(LETTERS, data_path)
-  pid <- publish_object(mn, data_path, "text/csv")
+  pid1 <- publish_object(mn, data_path, "text/csv")
+  pid2 <- publish_object(mn, data_path, "text/csv")
 
   eml_path <- file.path(system.file(package = "arcticdatautils"), "example-eml.xml")
 
@@ -119,28 +120,28 @@ test_that("a dataTable and otherEntity can be added from a pid", {
   dummy_entityDescription <- "Test_Description"
 
   # Create an otherEntity
-  OE <- pid_to_eml_entity(mn, pid,
+  OE <- pid_to_eml_entity(mn, pid1,
                     entityName = dummy_entityName,
                     entityDescription = dummy_entityDescription,
                     attributeList = dummy_attributeList)
-  expect_s4_class(OE, "otherEntity")
-  expect_true(slot(OE, "entityName") == dummy_entityName)
-  expect_true(slot(OE, "entityDescription") == dummy_entityDescription)
+
+  expect_true(OE$entityName == dummy_entityName)
+  expect_true(OE$entityDescription == dummy_entityDescription)
 
   # Create a dataTable
-  DT <- pid_to_eml_entity(mn, pid,
+  DT <- pid_to_eml_entity(mn, pid2,
                           entityType = "dataTable",
                           entityName = dummy_entityName,
                           entityDescription = dummy_entityDescription,
                           attributeList = dummy_attributeList)
-  expect_s4_class(DT, "dataTable")
-  expect_true(slot(DT, "entityName") == dummy_entityName)
-  expect_true(slot(DT, "entityDescription") == dummy_entityDescription)
 
-  doc@dataset@otherEntity[[1]] <- OE
+  expect_true(DT$entityName == dummy_entityName)
+  expect_true(DT$entityDescription == dummy_entityDescription)
+
+  doc$dataset$otherEntity <- OE
   expect_true(EML::eml_validate(doc))
 
-  doc@dataset@dataTable[[1]] <- DT
+  doc$dataset$dataTable <- DT
   expect_true(EML::eml_validate(doc))
 
   unlink(data_path)

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -2,17 +2,6 @@ context("EML")
 
 mn <- env_load()$mn
 
-test_that("a methods step can be added to an EML document", {
-  library(XML)
-  library(EML)
-
-  doc <- new("eml")
-  doc <- add_methods_step(doc, "title", "description")
-
-  expect_equal(XML::xmlValue(doc@dataset@methods@methodStep[[1]]@description@section[[1]]@.Data[[1]]), "title")
-  expect_equal(XML::xmlValue(doc@dataset@methods@methodStep[[1]]@description@section[[1]]@.Data[[2]]), "description")
-})
-
 test_that("multiple method steps can be added to an EML document", {
   library(XML)
   library(EML)

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -2,52 +2,28 @@ context("EML")
 
 mn <- env_load()$mn
 
-test_that("multiple method steps can be added to an EML document", {
-  library(XML)
-  library(EML)
-
-  doc <- new("eml")
-  doc <- add_methods_step(doc, "title", "description")
-  doc <- add_methods_step(doc, "another", "method")
-
-  expect_length(doc@dataset@methods@methodStep, 2)
-})
-
-test_that("methods can be cleared from an EML document", {
-  library(EML)
-
-  doc <- new("eml")
-  doc <- add_methods_step(doc, "title", "description")
-
-  expect_length(doc@dataset@methods@methodStep, 1)
-
-  doc <- clear_methods(doc)
-  expect_length(doc@dataset@methods@methodStep, 0)
-})
-
 test_that("a creator can be created", {
   creator <- eml_creator("test", "user")
 
-  expect_is(creator, "creator")
-  expect_equal(creator@individualName[[1]]@givenName[[1]]@.Data, "test")
-  expect_equal(creator@individualName[[1]]@surName@.Data, "user")
+  expect_equal(creator$individualName$givenName, "test")
+  expect_equal(creator$individualName$surName, "user")
 })
 
 test_that("a contact can be created", {
   contact <- eml_contact("test", "user")
 
   expect_is(contact, "contact")
-  expect_equal(contact@individualName[[1]]@givenName[[1]]@.Data, "test")
-  expect_equal(contact@individualName[[1]]@surName@.Data, "user")
+  expect_equal(contact$individualName$givenName, "test")
+  expect_equal(contact$individualName$surName, "user")
 })
 
 test_that("a personnel can be created", {
   personnel <- eml_personnel(given_names = "test", sur_name = "user", role = "principalInvestigator")
 
   expect_is(personnel, "personnel")
-  expect_equal(personnel@individualName[[1]]@givenName[[1]]@.Data, "test")
-  expect_equal(personnel@individualName[[1]]@surName@.Data, "user")
-  expect_equal(personnel@role[[1]]@.Data, "principalInvestigator")
+  expect_equal(personnel$individualName$givenName, "test")
+  expect_equal(personnel$individualName$surName, "user")
+  expect_equal(personnel$role, "principalInvestigator")
 })
 
 test_that("a project can be created", {


### PR DESCRIPTION
finished rewriting the `pid_to`... functions to be compatible with EML 2.2

Note that the ability to pass a list of pids to `pid_to_eml_physical` has been removed. Open to discussion on this 