### PR TITLE
bug in read_zip_shapefile where it can call "unzip" from the zip libr…

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -576,7 +576,7 @@ read_zip_shapefile <- function(mn, pid){
 
   temp <- tempfile()
   writeBin(dataone::getObject(mn, pid), temp)
-  zip_contents <- unzip(temp, exdir = tempfile())
+  zip_contents <- utils::unzip(temp, exdir = tempfile())
 
   if (length(grep("shp", tools::file_ext(zip_contents))) != 1){
     stop("Zipped directory must contain one and only one .shp file")


### PR DESCRIPTION
Found a bug in `read_zip_shapefile` where it can call `unzip` from either the utils or zip libraries, depending on which one is attached.  It fails when it calls unzip from the zip library so I added the utils namespace to the call. 