### PR TITLE
added reformat_file_name to publish_update

### DIFF
--- a/R/editing.R
+++ b/R/editing.R
@@ -496,6 +496,9 @@ publish_update <- function(mn,
     metadata_updated_sysmeta <- datapack::removeAccessRule(metadata_updated_sysmeta, "public", "read")
   }
 
+  # Update fileName to follow ADC naming conventions
+  metadata_updated_sysmeta@fileName <- reformat_file_name(eml@dataset@title[[1]]@.Data, metadata_updated_sysmeta)
+
   set_rights_holder(mn, metadata_pid, me)
 
   dataone::updateObject(mn,
@@ -1007,6 +1010,7 @@ reformat_file_name <- function(path, sysmeta) {
   }
 
   file_name <- stringr::str_replace_all(base_name, '[^[:alnum:]]', '_') %>%
+    stringr::str_replace_all('_[_]*', '_') %>%  # replaces consecutive underscores with one
     stringr::str_sub(end = -(nchar(ext) + 1)) %>%
     paste0(ext)
 


### PR DESCRIPTION
Added the file naming helper function to `publish_update`.   I didn't include this originally because I mistakenly thought `publish_update` called `arcticdatautils::update_object` - which calls this helper.  It actually calls `dataone::updateObject` so the helper needs to be added here as well.