### PR TITLE
Updated bug in reformat_file_name

### DIFF
--- a/R/editing.R
+++ b/R/editing.R
@@ -1003,6 +1003,8 @@ reformat_file_name <- function(path, sysmeta) {
       stringr::str_sub(1, 50)
     # re-trim if we're in the middle of a word and add extension back on
     index <- stringi::stri_locate_last_fixed(base_name, ' ')[1]
+    # Set index to the end of the string if there are no spaces.  Add + 1 because str_sub subtracts one to remove the white space.
+    if (is.na(index)) index <- nchar(base_name) + 1
     base_name <- stringr::str_sub(base_name, 1, index -1) %>%
       paste0(ext)
   } else {


### PR DESCRIPTION
Fixed a bug in `reformat_file_name` that sets the file name to `NA` if it doesn't contain any spaces.  @jeanetteclark I'm not really sure this needs a review but maybe you could test it out before I merge it?