### PR TITLE
return eml_validate check in eml_otherEntity_to_dataTable

### DIFF
--- a/R/eml.R
+++ b/R/eml.R
@@ -712,17 +712,17 @@ eml_otherEntity_to_dataTable <- function(doc, index, validate_eml = TRUE) {
 
   ## set OE entityTypes to NULL and select the ones we want to use
 
-  if (length(eml_get_simple(doc$dataset$otherEntity, "entityName")) == 1){
+  if (length(eml_get_simple(doc$dataset$otherEntity, "entityName")) == 1) {
     ## prepare OE to copy
     otherEntity <- doc$dataset$otherEntity
+    ## If there are copies of entities from the editor then otherEnt can incorrectly be a list
+    if (is.null(names(otherEntity))) {
+      otherEntity <- otherEntity[[1]]
+    }
     otherEntity$entityType <- NULL
-    otherEntity <- list(otherEntity)
     ## delete otherEntity from list
     doc$dataset$otherEntity <- NULL
-  }
-
-
-  else {
+  } else {
     otherEntity <- doc$dataset$otherEntity[index]
 
     for (i in 1:length(index)){
@@ -738,8 +738,7 @@ eml_otherEntity_to_dataTable <- function(doc, index, validate_eml = TRUE) {
   ## handle various datatable length cases
   if (length(dts) == 0){
     doc$dataset$dataTable <- otherEntity
-  }
-  else{
+  } else{
     if (length(eml_get_simple(dts, "entityName")) == 1){
       dts <- list(dts)
       doc$dataset$dataTable <- c(dts, otherEntity)
@@ -750,16 +749,14 @@ eml_otherEntity_to_dataTable <- function(doc, index, validate_eml = TRUE) {
     }
   }
 
-
-
-
   ## return eml
   if (validate_eml == TRUE) {
     valid_eml <- eml_validate(doc)
     if (!valid_eml) {
-      return(attributes(valid_eml))
+      stop(attributes(valid_eml))
     }
   }
+
   return(doc)
 }
 

--- a/R/eml.R
+++ b/R/eml.R
@@ -715,7 +715,7 @@ eml_otherEntity_to_dataTable <- function(doc, index, validate_eml = TRUE) {
   if (length(eml_get_simple(doc$dataset$otherEntity, "entityName")) == 1) {
     ## prepare OE to copy
     otherEntity <- doc$dataset$otherEntity
-    ## If there are copies of entities from the editor then otherEnt can incorrectly be a list
+    ## Handle case where otherEntity is in a list of length 1 (boxed)
     if (is.null(names(otherEntity))) {
       otherEntity <- otherEntity[[1]]
     }

--- a/R/eml.R
+++ b/R/eml.R
@@ -755,7 +755,10 @@ eml_otherEntity_to_dataTable <- function(doc, index, validate_eml = TRUE) {
 
   ## return eml
   if (validate_eml == TRUE) {
-    eml_validate(doc)
+    valid_eml <- eml_validate(doc)
+    if (!valid_eml) {
+      return(attributes(valid_eml))
+    }
   }
   return(doc)
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -273,6 +273,7 @@ create_dummy_parent_package <- function(mn, children) {
 #' }
 create_dummy_attributes_dataframe <- function(numberAttributes, factors = NULL) {
   names <- vapply(seq_len(numberAttributes), function(x) { paste0("Attribute ", x)}, "")
+  domains <- rep("textDomain", numberAttributes)
 
   if(!is.null(factors)) {
     domains <- c(rep("textDomain", numberAttributes - length(factors)),

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -134,6 +134,7 @@ test_that("eml_otherEntity_to_dataTable works", {
   }
 
   doc <- read_eml(system.file("example-eml.xml", package = "arcticdatautils"))
+  doc$dataset$otherEntity$attributeList <- EML::set_attributes(create_dummy_attributes_dataframe(1))
   otherEntity <- doc$dataset$otherEntity
 
   doc <- eml_otherEntity_to_dataTable(doc, 1)
@@ -142,8 +143,8 @@ test_that("eml_otherEntity_to_dataTable works", {
   expect_length(doc$dataset$otherEntity, 0)
 
   # test that dataTable was added
-  expect_equal(otherEntity$entityName, doc$dataset$dataTable[[1]]$entityName)
-  expect_equivalent(otherEntity$physical, doc$dataset$dataTable[[1]]$physical)
+  expect_equal(otherEntity$entityName, doc$dataset$dataTable$entityName)
+  expect_equivalent(otherEntity$physical, doc$dataset$dataTable$physical)
 })
 
 test_that("which_in_eml returns correct locations", {


### PR DESCRIPTION
I found that this function doesn't return an error if the `eml_validate` check fails.  Adding this in @jeanetteclark if you want to give it a quick review.  Curious to see if any of the unit tests fail now as well. 