### PR TITLE
Accounted for two word last names in eml_nsf_to_project

### DIFF
--- a/R/eml.R
+++ b/R/eml.R
@@ -1105,7 +1105,7 @@ extract_name <- function(x){
   lapply(x, function(x) {
     data.frame(
       firstName = trimws(stringr::str_extract(x, "[A-Za-z]{2,}\\s[A-Z]?")),
-      lastName = trimws(gsub("[A-Za-z]{2,}\\s[A-Z]?", "", x)),
+      lastName = trimws(gsub("^([A-Za-z]{2,})\\s[A-Z]?", "", x)),
       stringsAsFactors = F)})
 }
 

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -478,6 +478,11 @@ test_that('eml_nsf_to_project fails gracefully', {
 
 })
 
+test+that('eml_nsf_to_project parses two-word last names correctly', {
+  proj <- eml_nsf_to_project("1822406", eml_version = "2.2")
+
+  expect_equal(proj$personnel$individualName$givenName, "name")
+})
 
 test_that('Data object physical created for an EML', {
 

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -481,7 +481,7 @@ test_that('eml_nsf_to_project fails gracefully', {
 test+that('eml_nsf_to_project parses two-word last names correctly', {
   proj <- eml_nsf_to_project("1822406", eml_version = "2.2")
 
-  expect_equal(proj$personnel$individualName$givenName, "name")
+  expect_equal(proj$personnel$individualName$givenName, "Maria Val Martin")
 })
 
 test_that('Data object physical created for an EML', {

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -478,7 +478,7 @@ test_that('eml_nsf_to_project fails gracefully', {
 
 })
 
-test+that('eml_nsf_to_project parses two-word last names correctly', {
+test_that('eml_nsf_to_project parses two-word last names correctly', {
   proj <- eml_nsf_to_project("1822406", eml_version = "2.2")
 
   expect_equal(proj$personnel$individualName$givenName, "Maria Val Martin")

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -481,8 +481,8 @@ test_that('eml_nsf_to_project fails gracefully', {
 test_that('eml_nsf_to_project parses two-word last names correctly', {
   proj <- eml_nsf_to_project("1822406", eml_version = "2.2")
 
-  expect_equal(proj$personnel$individualName$givenName, "Maria")
-  expect_equal(proj$personnel$individualName$surName, "Val Martin")
+  expect_equal(proj$personnel[[1]]$individualName$givenName, "Maria")
+  expect_equal(proj$personnel[[1]]$individualName$surName, "Val Martin")
 })
 
 test_that('Data object physical created for an EML', {

--- a/tests/testthat/test_eml.R
+++ b/tests/testthat/test_eml.R
@@ -481,7 +481,8 @@ test_that('eml_nsf_to_project fails gracefully', {
 test_that('eml_nsf_to_project parses two-word last names correctly', {
   proj <- eml_nsf_to_project("1822406", eml_version = "2.2")
 
-  expect_equal(proj$personnel$individualName$givenName, "Maria Val Martin")
+  expect_equal(proj$personnel$individualName$givenName, "Maria")
+  expect_equal(proj$personnel$individualName$surName, "Val Martin")
 })
 
 test_that('Data object physical created for an EML', {


### PR DESCRIPTION
- fixed `eml_nsf_to_project` parsing two word last names (like "Val Martin") incorrectly

resolves #188 