### PR TITLE
Update install_github in README to use main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To install the latest version of this package we recommend installing from Githu
 
 ```r
 
-remotes::install_github("nceas/arcticdatautils")
+remotes::install_github("nceas/arcticdatautils@main")
 
 ```
 


### PR DESCRIPTION
I tried to copy/paste the install_github() command from the README and got an error about the `master` branch missing. So I added the `@main` ref so that it will work