### PR TITLE
raster helper function edits: attributeList

### DIFF
--- a/R/eml.R
+++ b/R/eml.R
@@ -461,11 +461,11 @@ extract_name <- function(x){
 #'
 #' @param path (char) Path to a raster file
 #' @param coord_name (char) horizCoordSysDef name
-#' @param attributes (dataTable) attributes for raster
+#' @param attributeList (list) Entity attributeList for raster
 #'
 #'
 #' @export
-eml_get_raster_metadata <- function(path, coord_name = NULL, attributes){
+eml_get_raster_metadata <- function(path, coord_name = NULL, attributeList){
 
   raster_obj <- raster::raster(path)
   message(paste("Reading raster object with proj4string of ", raster::crs(raster_obj)@projargs))
@@ -483,7 +483,7 @@ eml_get_raster_metadata <- function(path, coord_name = NULL, attributes){
   }
 
   raster_info <- list(entityName = basename(path),
-                      attributeList = set_attributes(attributes),
+                      attributeList = attributeList,
                       spatialReference = list(horizCoordSysName = coord_name),
                       horizontalAccuracy = list(accuracyReport = "unknown"),
                       verticalAccuracy = list(accuracyReport = "unknown"),


### PR DESCRIPTION
Changed the usage of an attributes data frame to a listed attributeList within the function, and edited the documentation to reflect those changes. 

From what I've seen, most PIs input the raster layer in the web editor, so converting the single attributeList to a data frame feels like an odd side-step. If a raster is missing an attributeList, I think the better way forward would be to create an attList either through the webform or Shiny. If done through Shiny, then running `set_attributes()` and adding it back to the `otherEntity` before converting to a `spatialRaster`, rather than reverting an attList to a data frame.