### PR TITLE
Adding version specification to jsonlite pckg in description file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     digest,
     EML (>= 2.0),
     httr,
-    jsonlite,
+    jsonlite (>= 1.8.4),
     magrittr,
     methods,
     stringr,

--- a/R/eml.R
+++ b/R/eml.R
@@ -354,7 +354,7 @@ eml_nsf_to_project <- function(awards, eml_version = "2.2"){
   award_nums <- awards
 
   result <- lapply(award_nums, function(x){
-    url <- paste0("https://api.nsf.gov/services/v1/awards.json?id=", x ,"&printFields=coPDPI,pdPIName,title")
+    url <- paste0("https://www.research.gov/awardapi-service/v1/awards.json?id=", x ,"&printFields=coPDPI,pdPIName,title")
 
     t <- tryCatch(jsonlite::fromJSON(url),
                   error = function(j) {


### PR DESCRIPTION
New errors running `eml_nsf_to_project()` cropped up recently that seem to be (mostly) resolved by updating the jsonlite package from the systemwide `1.8.0` version to `.1.8.4`. Making the change in the description file to make sure `{arcticdatautils}` loads the specific version moving forward.